### PR TITLE
Add monte-carlo solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.csv
 *.jpg
 *.asc
 *.tif

--- a/unmix_mwe.py
+++ b/unmix_mwe.py
@@ -52,7 +52,7 @@ for sample, values in element_pred_down_mc.items():
 
 # print(downstream_uncerts)
 
-area_dict = gio.get_unique_upstreamz_areas(sample_network)  # Extract areas for each basin
+area_dict = gio.get_unique_upstream_areas(sample_network)  # Extract areas for each basin
 upstream_map = gio.get_upstream_concentration_map(
     area_dict, element_pred_upstream
 )  # Assign to upstream preds

--- a/unmix_mwe.py
+++ b/unmix_mwe.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 from matplotlib.colors import LogNorm
 

--- a/unmix_mwe.py
+++ b/unmix_mwe.py
@@ -36,7 +36,23 @@ element_pred_down, element_pred_upstream = problem.solve(
     element_data, solver="ecos", regularization_strength=10 ** (-3)
 )  # Solve problem
 
-area_dict = gio.get_unique_upstream_areas(sample_network)  # Extract areas for each basin
+relative_error = 10  #%
+print("Calculating uncertainties with monte-carlo sampling")
+element_pred_down_mc, element_pred_up_mc = problem.solve_montecarlo(
+    element_data,
+    relative_error=relative_error,
+    num_repeats=50,
+    regularization_strength=regularizer_strength,
+    solver="ecos",
+)
+
+downstream_uncerts = {}
+for sample, values in element_pred_down_mc.items():
+    downstream_uncerts[sample] = np.std(values)
+
+# print(downstream_uncerts)
+
+area_dict = gio.get_unique_upstreamz_areas(sample_network)  # Extract areas for each basin
 upstream_map = gio.get_upstream_concentration_map(
     area_dict, element_pred_upstream
 )  # Assign to upstream preds


### PR DESCRIPTION
Add method to SampleNetwork class that performs a monte carlo estimation of uncertainty on predictions (upstream and downstream) by propagating a provided relative observational error through the unmixing routine. 
