### PR TITLE
Add missing DefaultDict import and regularizer_strength definition

### DIFF
--- a/geochem_inverse_optimize.py
+++ b/geochem_inverse_optimize.py
@@ -2,7 +2,7 @@
 
 import os
 import tempfile
-from typing import Dict, Final, Iterator, List, Optional, Tuple
+from typing import DefaultDict, Dict, Final, Iterator, List, Optional, Tuple
 
 # TODO(rbarnes): Make a requirements file for conda
 import cvxpy as cp
@@ -206,8 +206,8 @@ class SampleNetwork:
         regularization_strength: float,
         solver: str = "gurobi",
     ):
-        predictions_down_mc = defaultdict(list)
-        predictions_up_mc = defaultdict(list)
+        predictions_down_mc = DefaultDict(list)
+        predictions_up_mc = DefaultDict(list)
         for i in range(num_repeats):
             observation_data_resampled = {
                 sample: value * np.random.normal(loc=1, scale=relative_error / 100)

--- a/unmix_mwe.py
+++ b/unmix_mwe.py
@@ -18,6 +18,7 @@ obs_data = obs_data.drop(columns=["Bi", "S"])
 
 element = "Mg"  # Set element
 sample_network, sample_adjacency = gio.get_sample_graphs("data/")
+regularizer_strength = 10 ** (-2.5)
 
 # plt.figure(figsize=(15, 10))  # Visualise network
 # gio.plot_network(sample_network)


### PR DESCRIPTION
Couple errors have crept into main branch, from recent merges:

1. `DefaultDict` import statement is missing in `geochem_inverse_optimize`
2. `DefaultDict` used erroneously as `defaultdict`  
3. `regularizer_strength` not defined in `unmix.py`. 

This PR fixes the above. 