### PR TITLE
Add regularization by penalising relative deviations from mean

### DIFF
--- a/geochem_inverse_optimize.py
+++ b/geochem_inverse_optimize.py
@@ -194,18 +194,10 @@ class SampleNetwork:
                 )
 
     def _build_regularizer_terms_discrete(self) -> None:
-        # Build regularizer
-        if not self.sample_adjacency:
-            raise Exception("Sample adjacency (sample_adjacency) not provided")
-
-        # Loop through all samples in drainage network
-        for adjacent_nodes, border_length in self.sample_adjacency.items():
-            a_concen = self.sample_network.nodes[adjacent_nodes[0]]["data"].my_value
-            b_concen = self.sample_network.nodes[adjacent_nodes[1]]["data"].my_value
-            # TODO: Make difference a log-ratio
-            # self._regularizer_terms.append(border_length * (cp_log_ratio(a_concen,b_concen)))
-            # Simple difference (not desirable)
-            self._regularizer_terms.append(border_length * (a_concen - b_concen))
+        # Build regularizer                
+        for _, data in self.sample_network.nodes(data=True):
+            concen = data["data"].my_value
+            self._regularizer_terms.append(cp.maximum(concen, cp.inv_pos(concen)))
 
     def _build_problem(self) -> None:
         assert self._primary_terms


### PR DESCRIPTION
We currently regularise by penalising the *roughness* of the proposed solution, considering adjacent nodes. However, this considers only absolute difference between nodes when relative deviations are desired. This current method produces results which thus allow for significant overfitting of low-magnitude observations (i.e., orders of magnitude below one) which is undesirable for fitting (for example) trace element concentrations. An example of these undesirable outputs are shown here: 
![old_regularization](https://user-images.githubusercontent.com/10188895/205090502-b5c34f28-09b3-4fdc-8aa7-649ebccb4865.png)

In this PR, I instead penalise *relative* deviations of each variable from the mean of all observations. This permits slightly 'rougher' solutions, but inspecting the results, the results are elsewise much better conditioned. Specifically, no longer do we see outputs spuriously spanning many orders of magnitude below, as shown in the example below which is same as example above but with new regularization method: 

![new_regularization](https://user-images.githubusercontent.com/10188895/205090417-d6ff0090-98bf-44e0-9782-7010b33ed405.png)

This PR removes the need for an adjacency matrix which also simplifies the code. 