### PR TITLE
Add mix_downstream function & synthetic inverse test

### DIFF
--- a/synthetic_test.py
+++ b/synthetic_test.py
@@ -1,0 +1,65 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+import geochem_inverse_optimize as gio
+
+max_val = 1000  # maximum value for synthetic input
+rel_err = 5  # 5% relative error
+
+# Load in Drainage Network
+sample_network, sample_adjacency = gio.get_sample_graphs("data/d8.asc", "data/sample_data.dat")
+# Get upstream basins
+areas = gio.get_unique_upstream_areas(sample_network)
+
+# Pick random values to set each basin
+synth_upst_concs = {sample: max_val * np.random.rand() for sample in areas.keys()}
+# Generate synthetic upstream concentration map
+upst_conc_map = gio.get_upstream_concentration_map(areas, synth_upst_concs)
+# Predict concentration at downstream observation points
+mixed_synth_down, _ = gio.mix_downstream(sample_network, areas, upst_conc_map)
+## Add noise
+# mixed_synth_down = {
+#     sample: value * np.random.normal(loc=1, scale=rel_err / 100)
+#     for sample, value in mixed_synth_down.items()
+# }
+# Set up problem
+problem = gio.SampleNetwork(sample_network, sample_adjacency, use_regularization=False)
+# Solve problem using synthetic downstream observations as input
+recovered_down, recovered_up = problem.solve(mixed_synth_down, solver="ecos")
+# Generate recovered upstream concentration map
+recovered_conc_map = gio.get_upstream_concentration_map(areas, recovered_up)
+
+# Extract arrays of predicted and `observed' concentrations
+down_preds = [recovered_down[sample] for sample in recovered_down.keys()]
+down_obs = [mixed_synth_down[sample] for sample in recovered_down.keys()]
+up_preds = [recovered_up[sample] for sample in recovered_down.keys()]
+up_obs = [synth_upst_concs[sample] for sample in recovered_down.keys()]
+
+# Visualise results of synthetic test
+plt.figure(figsize=(15, 15))
+plt.subplot(2, 2, 1)
+plt.title("Inputted")
+plt.imshow(upst_conc_map, vmin=0, vmax=1000)
+cb = plt.colorbar()
+cb.set_label("Concentration")
+plt.subplot(2, 2, 2)
+plt.title("Recovered")
+plt.imshow(recovered_conc_map, vmin=0, vmax=1000)
+plt.subplot(2, 2, 3)
+plt.plot([0, 1e6], [0, 1e6], alpha=0.5, color="grey")
+plt.scatter(down_obs, down_preds)
+plt.axis("equal")
+plt.xlim(0, max_val)
+plt.ylim(0, max_val)
+plt.xlabel("Synthetic downstream concentration")
+plt.ylabel("Recovered downstream concentration")
+plt.subplot(2, 2, 4)
+plt.plot([0, 1e6], [0, 1e6], alpha=0.5, color="grey")
+plt.scatter(up_obs, up_preds)
+plt.axis("equal")
+plt.xlim(0, max_val)
+plt.ylim(0, max_val)
+plt.xlabel("Synthetic upstream concentration")
+plt.ylabel("Recovered upstream concentration")
+plt.tight_layout()
+plt.show()


### PR DESCRIPTION
Adds a script that runs a synthetic inversion test that confirms inversion scheme working as expected. This uses new `mix_downstream' function which mixes a given geochemical raster map, prediction composition at the sample sites.