### PR TITLE
D8 boundary conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This repository implements an efficient solution to the unmixing of nested concentrations in a (river) network using convex optimisation. The method is described in our [EGU abstract](https://meetingorganizer.copernicus.org/EGU23/EGU23-5368.html) 
 
-## Data input assumptions 
+## Data input assumptions
 
 The algorithm requires:
 
-1) A GDAL readable raster of D8 flow directions. We use the ESRI/Arc D8 convention of representing directions with increasing powers of 2 (i.e., 1, 2, 4, 8 etc.) with sink pixels indicated by 0. 
+1) A GDAL readable raster of D8 flow directions. We use the ESRI/Arc D8 convention of representing directions with increasing powers of 2 (i.e., 1, 2, 4, 8 etc.) with sink pixels indicated by 0. We assume that every cell in the domain eventually flows into a sink node within the domain (or is itself a sink node). This assumption requires that **every boundary pixel is set to be a sink**.
 
-2) A tab-delimited file which contains the names, locations and geochemical observations at the sample sites. Sample names are given in column `Sample.Code`, and the x and y-coordinates of the sample sites in columns `x_coordinate` and `y_coordinate`. The x and y-coordinates of the sample sites should correspond to the *upper left* corner of pixels, in the same reference system as the D8 raster. It is assumed that the sample sites have already been manually aligned onto the drainage grid.  Subsequent columns contain the name of a given tracer (e.g., `Mg`) and their concentrations (arbitrary units). 
+2) A tab-delimited file which contains the names, locations and geochemical observations at the sample sites. Sample names are given in column `Sample.Code`, and the x and y-coordinates of the sample sites in columns `x_coordinate` and `y_coordinate`. The x and y-coordinates of the sample sites need to be in the same reference system as the D8 raster. It is assumed that the sample sites have already been manually aligned onto the drainage network.  Subsequent columns contain the name of a given tracer (e.g., `Mg`) and their concentrations (arbitrary units).
 
 Example datasets are given in `data/d8.asc` and `sample_data.dat`.
 

--- a/src/faster-unmixer.cpp
+++ b/src/faster-unmixer.cpp
@@ -146,6 +146,17 @@ std::pair<std::vector<internal::SampleNode>, internal::NeighborsToBorderLength> 
   convert_arc_flowdirs_to_richdem_d8(arc_flowdirs, flowdirs);
   flowdirs.saveGDAL("rd_flowdirs.tif");
 
+  // Check that boundary conditions are correct
+  iterate_2d(flowdirs, [&](const auto x, const auto y){
+    // if x,y is on the boundary and the node is not a sink raise an exception:
+    if(
+      (x==0 || y==0 || x==flowdirs.width()-1 || y==flowdirs.height()-1) &&
+      flowdirs(x,y)!=NO_FLOW
+    ){
+      throw std::runtime_error("Boundary condition violated at (" + std::to_string(x) + ", " + std::to_string(y) + ")! Expected a sink node, but got a flow direction!");
+    }
+  });
+
   // Get geotransform info from raster
   // Extract GDAL origin (upper left) + pixel widths
   const auto originX = flowdirs.geotransform[0];
@@ -310,5 +321,4 @@ std::pair<SampleGraph, NeighborsToBorderLength> faster_unmixer(const std::string
 
   return {nodes, adjacency_graph_external};
 }
-
 }

--- a/src/faster-unmixer.cpp
+++ b/src/faster-unmixer.cpp
@@ -321,4 +321,5 @@ std::pair<SampleGraph, NeighborsToBorderLength> faster_unmixer(const std::string
 
   return {nodes, adjacency_graph_external};
 }
+
 }


### PR DESCRIPTION
Currently, to build the sample network in `faster-unmixer.cpp` we iterate from sink nodes, upstream into the headwaters and label any sample nodes we discover as we go. This assumes that every cell in the domain drains into a sink node within the domain. If this is not the case an exception is raised indicating that the network area is not equal to the area of the domain. This means that in practise we often require the input D8 raster to have a boundary condition of sink nodes. 

This PR makes this data assumption explicit. `faster-unmixer.cpp` now raises an exception if there are any boundary nodes which are not sinks. Additionally, it updates the data input assumptions in the read-me file to reflect this boundary condition assumption (and corrects mistakes in the data assumption about the coordinates) 

This patches issue #42 but longer term we may wish to restructure the network building procedure to not require this boundary condition. 