### PR TITLE
Add CLARABEL solver

### DIFF
--- a/funmixer/network_unmixer.py
+++ b/funmixer/network_unmixer.py
@@ -136,6 +136,7 @@ SOLVERS: Dict[str, Any] = {
     },
     "scs": {"solver": cp.SCS, "verbose": False, "max_iters": 10000},
     "gurobi": {"solver": cp.GUROBI, "verbose": False, "NumericFocus": 3},
+    "clarabel": {"solver": cp.CLARABEL, "verbose": False},
 }
 
 logger: logging.Logger = logging.getLogger()

--- a/tests/runtime_benchmark.py
+++ b/tests/runtime_benchmark.py
@@ -176,8 +176,11 @@ def do_benchmark() -> None:
     print("Testing SCS solver...")
     scs_bench = run_benchmark("scs", network_sizes)
 
+    print("Testing Clarabel solver...")
+    clarabel_bench = run_benchmark("clarabel", network_sizes)
+
     with open("benchmark_results.pkl", "wb") as fout:
-        pickle.dump([network_sizes, ecos_bench, gurobi_bench, scs_bench], fout)
+        pickle.dump([network_sizes, ecos_bench, gurobi_bench, scs_bench, clarabel_bench], fout)
 
     end = time.time()
     print(f"Benchmarking took {end - start} seconds.")
@@ -187,8 +190,13 @@ def do_benchmark() -> None:
 
 def plot_benchmark() -> None:
     with open("benchmark_results.pkl", "rb") as fin:
-        network_sizes, ecos_bench, gurobi_bench, scs_bench = pickle.load(fin)
-    breakpoint()
+        (
+            network_sizes,
+            ecos_bench,
+            gurobi_bench,
+            scs_bench,
+            clarabel_bench,
+        ) = pickle.load(fin)
 
     # Plot results of total runtime
     # Plot solve time against number of nodes
@@ -199,6 +207,7 @@ def plot_benchmark() -> None:
     plot_first_second(network_sizes, scs_bench, "SCS", "#e31a1c", "#fb9a99", scale=1e-3)
     if gurobi_bench:
         plot_first_second(network_sizes, gurobi_bench, "GUROBI", "#33a02c", "#b2df8a")
+    plot_first_second(network_sizes, clarabel_bench, "CLARABEL", "#ff7f00", "#fdbf6f", scale=1e-3)
 
     ax.set_xscale("log")
     ax.set_yscale("log")
@@ -213,7 +222,9 @@ def plot_benchmark() -> None:
     )
     if gurobi_bench:
         plot_solver_time(network_sizes, gurobi_bench, "GUROBI Solver Time", "#33a02c", symbol="o--")
-
+    plot_solver_time(
+        network_sizes, clarabel_bench, "CLARABEL Solver Time", "#ff7f00", scale=1e-3, symbol="o--"
+    )
     ax.set_xscale("log")
     ax.set_title("Optimizer time")
     ax.set_yscale("log")

--- a/tests/runtime_benchmark.py
+++ b/tests/runtime_benchmark.py
@@ -207,7 +207,7 @@ def plot_benchmark() -> None:
     plot_first_second(network_sizes, scs_bench, "SCS", "#e31a1c", "#fb9a99", scale=1e-3)
     if gurobi_bench:
         plot_first_second(network_sizes, gurobi_bench, "GUROBI", "#33a02c", "#b2df8a")
-    plot_first_second(network_sizes, clarabel_bench, "CLARABEL", "#ff7f00", "#fdbf6f", scale=1e-3)
+    plot_first_second(network_sizes, clarabel_bench, "CLARABEL", "#ff7f00", "#fdbf6f")
 
     ax.set_xscale("log")
     ax.set_yscale("log")
@@ -222,9 +222,7 @@ def plot_benchmark() -> None:
     )
     if gurobi_bench:
         plot_solver_time(network_sizes, gurobi_bench, "GUROBI Solver Time", "#33a02c", symbol="o--")
-    plot_solver_time(
-        network_sizes, clarabel_bench, "CLARABEL Solver Time", "#ff7f00", scale=1e-3, symbol="o--"
-    )
+    plot_solver_time(network_sizes, clarabel_bench, "CLARABEL Solver Time", "#ff7f00", symbol="o--")
     ax.set_xscale("log")
     ax.set_title("Optimizer time")
     ax.set_yscale("log")


### PR DESCRIPTION
Issue #51 raised that ECOS is no-longer the default solver of choice for CVXPY. Whilst we do not use ECOS by default, it would be desirable to include the functionality for the replacement solver for ECOS, which is [CLARABEL](https://oxfordcontrol.github.io/ClarabelDocs/stable/). This PR adds in CLARABEL as a solver of choice in the NetworkUnmixer class. It also adds it as a tested solver in the run-time benchmark.  