### PR TITLE
Remove erroneous SCS runtime scaling factor

### DIFF
--- a/tests/runtime_benchmark.py
+++ b/tests/runtime_benchmark.py
@@ -188,7 +188,6 @@ def do_benchmark() -> None:
 def plot_benchmark() -> None:
     with open("benchmark_results.pkl", "rb") as fin:
         network_sizes, ecos_bench, gurobi_bench, scs_bench = pickle.load(fin)
-    # breakpoint()
 
     # Plot results of total runtime
     # Plot solve time against number of nodes

--- a/tests/runtime_benchmark.py
+++ b/tests/runtime_benchmark.py
@@ -188,7 +188,7 @@ def do_benchmark() -> None:
 def plot_benchmark() -> None:
     with open("benchmark_results.pkl", "rb") as fin:
         network_sizes, ecos_bench, gurobi_bench, scs_bench = pickle.load(fin)
-    breakpoint()
+    # breakpoint()
 
     # Plot results of total runtime
     # Plot solve time against number of nodes
@@ -196,7 +196,7 @@ def plot_benchmark() -> None:
     ax = fig.add_subplot(111)
 
     plot_first_second(network_sizes, ecos_bench, "ECOS", "#1f78b4", "#a6cee3")
-    plot_first_second(network_sizes, scs_bench, "SCS", "#e31a1c", "#fb9a99", scale=1e-3)
+    plot_first_second(network_sizes, scs_bench, "SCS", "#e31a1c", "#fb9a99")
     if gurobi_bench:
         plot_first_second(network_sizes, gurobi_bench, "GUROBI", "#33a02c", "#b2df8a")
 
@@ -208,9 +208,7 @@ def plot_benchmark() -> None:
 
     # Plot results of just the CVXPY solve time
     plot_solver_time(network_sizes, ecos_bench, "ECOS Solver Time", "#1f78b4", symbol="o--")
-    plot_solver_time(
-        network_sizes, scs_bench, "SCS Solver Time", "#e31a1c", scale=1e-3, symbol="o--"
-    )
+    plot_solver_time(network_sizes, scs_bench, "SCS Solver Time", "#e31a1c", symbol="o--")
     if gurobi_bench:
         plot_solver_time(network_sizes, gurobi_bench, "GUROBI Solver Time", "#33a02c", symbol="o--")
 


### PR DESCRIPTION
Issue #54 highlighted that the run-time plotting script suggests the SCS solver is three orders of magnitude greater than the ECOS and GUROBI solvers. This error was introduced by an erroneous (or legacy) scaling factor in the plotting script for the SCS solver. This PR removes the scaling factor.

An ?erroneous debugging breakpoint is also commented out.